### PR TITLE
feat: base implementation for slowloris simulation

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -30,6 +30,7 @@ func NewApp(f embed.FS) *fiber.App {
 	v1 := api.Group("/v1")
 	v1.Get("/requests", handleGetAllRequests)
 	v1.Get("/requests/:key", handleGetRequestByKey)
+	v1.Get("/slowloris", handleGetSlowloris)
 
 	app.Use(handleAnyRequest)
 

--- a/internal/api/slowloris.go
+++ b/internal/api/slowloris.go
@@ -1,0 +1,43 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+package api
+
+import (
+	"bufio"
+	"cosmoparrot/internal/config"
+	"github.com/gofiber/fiber/v2"
+	"time"
+)
+
+func handleGetSlowloris(ctx *fiber.Ctx) error {
+	ctx.Set("Content-Type", "text/plain")
+
+	durationSec := config.LoadedConfiguration.SlowlorisDefaultDurationSeconds
+	if d := ctx.Query("duration"); d != "" {
+		if parsed, err := time.ParseDuration(d + "s"); err == nil && parsed > 0 {
+			durationSec = int(parsed.Seconds())
+		}
+	}
+
+	// add a query parameter to set the time between single dots
+	intervalSec := config.LoadedConfiguration.SlowlorisDefaultIntervalSeconds
+	if t := ctx.Query("interval"); t != "" {
+		if parsed, err := time.ParseDuration(t + "s"); err == nil && parsed > 0 {
+			intervalSec = int(parsed.Seconds())
+		}
+	}
+
+	ctx.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		start := time.Now()
+		for i := 0; ; i++ {
+			if time.Since(start) > time.Duration(durationSec)*time.Second {
+				break
+			}
+			w.WriteByte('.')
+			w.Flush()
+			time.Sleep(time.Duration(intervalSec) * time.Second)
+		}
+	})
+	return nil
+}

--- a/internal/api/slowloris_test.go
+++ b/internal/api/slowloris_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+package api
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleGetSlowloris(t *testing.T) {
+	app := fiber.New()
+	app.Get("/slowloris", handleGetSlowloris)
+
+	req := httptest.NewRequest("GET", "/slowloris?duration=9&interval=3", nil)
+	resp, err := app.Test(req, 10000)
+	assert.NoError(t, err)
+	assert.Equal(t, resp.StatusCode, http.StatusOK)
+
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(body))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,10 +19,12 @@ func init() {
 }
 
 type configuration struct {
-	Port                      int      `mapstructure:"port"`
-	ResponseCode              int      `mapstructure:"responseCode"`
-	MethodResponseCodeMapping []string `mapstructure:"methodResponseCodeMapping"`
-	StoreKeyRequestHeaders    []string `mapstructure:"storeKeyRequestHeaders"`
+	Port                            int      `mapstructure:"port"`
+	ResponseCode                    int      `mapstructure:"responseCode"`
+	MethodResponseCodeMapping       []string `mapstructure:"methodResponseCodeMapping"`
+	StoreKeyRequestHeaders          []string `mapstructure:"storeKeyRequestHeaders"`
+	SlowlorisDefaultDurationSeconds int      `mapstructure:"slowlorisDefaultDurationSeconds"`
+	SlowlorisDefaultIntervalSeconds int      `mapstructure:"slowlorisDefaultIntervalSeconds"`
 }
 
 func setDefaults() {
@@ -30,6 +32,8 @@ func setDefaults() {
 	viper.SetDefault("responseCode", 200)
 	viper.SetDefault("methodResponseCodeMapping", []string{})
 	viper.SetDefault("storeKeyRequestHeaders", []string{"x-request-key"})
+	viper.SetDefault("slowlorisDefaultDurationSeconds", 15)
+	viper.SetDefault("slowlorisDefaultIntervalSeconds", 1)
 }
 
 func loadConfiguration() {


### PR DESCRIPTION
Added a base implementation for a slowloris endpoint simulation a configurable slow provider that only responds with a dot for every interval given over a max duration.