### PR TITLE
feat: add high-performance /api/v1/devnull sink endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,26 @@ Cosmoparrot supports configuration via environment variables and/or a configurat
 | responseCode                | COSMOPARROT_RESPONSECODE              | int    | 200     | Enforces a specific HTTP response code. Can be used to test different consumer behavior. |
 | methodResponseCodeMapping   | COSMOPARROT_METHODRESPONSECODEMAPPING | string | ""      | Control the HTTP response code per HTTP method, for example: "POST:401"                  |
 
+## Endpoints
+
+### Echo (catch-all)
+Any request that does not match a specific route is handled by the echo handler. It mirrors the request back as a JSON response including path, method, headers, and body.
+
+### `/api/v1/devnull`
+A high-performance sink endpoint that accepts any HTTP method. It reads and discards the request payload without parsing, logging, or storing anything — making it safe for sustained high-throughput scenarios with no risk of OOM.
+
+- Returns the configured response code (default `200`).
+- Supports `?responseCode=<code>` query parameter to override the status code per request.
+
+### `/api/v1/requests`
+Returns all stored requests as JSON (requires store key headers to be configured).
+
+### `/api/v1/requests/:key`
+Returns stored requests for a specific key.
+
+### `/api/v1/slowloris`
+Simulates a [slowloris](https://en.wikipedia.org/wiki/Slowloris_(computer_security)) response by streaming data slowly. Supports `?duration=<seconds>` and `?interval=<seconds>` query parameters.
+
 ## Running Cosmoparrot
 ### Locally
 

--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -126,23 +126,8 @@ func getResponseCode(c *fiber.Ctx) int {
 		// invalid override -> fallthrough to mapping/default
 	}
 
-	mapping := config.LoadedConfiguration.MethodResponseCodeMapping
-
-	for _, m := range mapping {
-		s := strings.Split(m, ":")
-		if len(s) == 2 {
-			if strings.ToUpper(strings.TrimSpace(s[0])) == c.Method() {
-
-				responseCode, err := strconv.Atoi(s[1])
-				if err != nil {
-					log.Errorf("could not successfully parse method request code mapping configuration. Fallback to request code: %d", config.LoadedConfiguration.ResponseCode)
-
-					return config.LoadedConfiguration.ResponseCode
-				}
-
-				return responseCode
-			}
-		}
+	if code, ok := config.LoadedConfiguration.MethodResponseCodeMap[c.Method()]; ok {
+		return code
 	}
 
 	return config.LoadedConfiguration.ResponseCode

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -15,16 +15,10 @@ import (
 	"net/http"
 )
 
-var app *fiber.App
-
-func init() {
-	app = fiber.New()
-	app.Use(createNewLogHandler())
-
-}
-
 func NewApp(f embed.FS) *fiber.App {
-	app := fiber.New()
+	app := fiber.New(fiber.Config{
+		StreamRequestBody: true,
+	})
 	app.Use(createNewLogHandler())
 	app.Use(healthcheck.New())
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -33,6 +33,7 @@ func NewApp(f embed.FS) *fiber.App {
 	v1.Get("/requests", handleGetAllRequests)
 	v1.Get("/requests/:key", handleGetRequestByKey)
 	v1.Get("/slowloris", handleGetSlowloris)
+	v1.All("/devnull", handleDevNull)
 
 	app.Use(handleAnyRequest)
 

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -6,12 +6,17 @@ package api
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 )
 
 func getLoggerConfig() logger.Config {
 	return logger.Config{
+		Next: func(c *fiber.Ctx) bool {
+			return strings.HasPrefix(c.Path(), "/api/v1/devnull")
+		},
 		Format:   "${green}→ Request received:\n${reset}${time} | ${status} - ${method} ${path}\n${green}→ Request headers:${magenta}\n${custom_tag}${green}→ Request body:${cyan}\n${body}${reset}\n",
 		TimeZone: "UTC",
 		CustomTags: map[string]logger.LogFunc{

--- a/internal/api/devnull.go
+++ b/internal/api/devnull.go
@@ -1,0 +1,15 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+func handleDevNull(c *fiber.Ctx) error {
+	// Body is already read by Fiber into c.Body(); we simply ignore it.
+	// No deserialization, no caching, no logging — just return the status code.
+	return c.SendStatus(getResponseCode(c))
+}

--- a/internal/api/devnull.go
+++ b/internal/api/devnull.go
@@ -9,7 +9,7 @@ import (
 )
 
 func handleDevNull(c *fiber.Ctx) error {
-	// Body is already read by Fiber into c.Body(); we simply ignore it.
-	// No deserialization, no caching, no logging — just return the status code.
+	// With StreamRequestBody enabled, the body is never read into memory
+	// because we never call c.Body(). No deserialization, no caching, no logging.
 	return c.SendStatus(getResponseCode(c))
 }

--- a/internal/api/devnull_test.go
+++ b/internal/api/devnull_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHandleDevNull_POST(t *testing.T) {
+	app := fiber.New()
+	app.All("/api/v1/devnull", handleDevNull)
+
+	body := []byte(`{"message": "should be discarded"}`)
+	r := httptest.NewRequest("POST", "/api/v1/devnull", bytes.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(r, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHandleDevNull_GET(t *testing.T) {
+	app := fiber.New()
+	app.All("/api/v1/devnull", handleDevNull)
+
+	r := httptest.NewRequest("GET", "/api/v1/devnull", nil)
+
+	resp, err := app.Test(r, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestHandleDevNull_CustomResponseCode(t *testing.T) {
+	app := fiber.New()
+	app.All("/api/v1/devnull", handleDevNull)
+
+	r := httptest.NewRequest("POST", "/api/v1/devnull?responseCode=201", bytes.NewReader([]byte(`{}`)))
+	r.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(r, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+}
+
+func TestHandleDevNull_LargeBody(t *testing.T) {
+	app := fiber.New()
+	app.All("/api/v1/devnull", handleDevNull)
+
+	largeBody := make([]byte, 1024*1024) // 1 MB
+	for i := range largeBody {
+		largeBody[i] = 'x'
+	}
+
+	r := httptest.NewRequest("PUT", "/api/v1/devnull", bytes.NewReader(largeBody))
+
+	resp, err := app.Test(r, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}

--- a/internal/api/getresponsecode_test.go
+++ b/internal/api/getresponsecode_test.go
@@ -18,6 +18,7 @@ func TestGetResponseCode_QueryParamPrecedence(t *testing.T) {
 	// ensure default
 	config.LoadedConfiguration.ResponseCode = 201
 	config.LoadedConfiguration.MethodResponseCodeMapping = []string{"GET:202", "POST:203"}
+	config.LoadedConfiguration.BuildMethodResponseCodeMap()
 
 	app := fiber.New()
 	app.Get("/test", func(c *fiber.Ctx) error {
@@ -33,6 +34,7 @@ func TestGetResponseCode_QueryParamPrecedence(t *testing.T) {
 func TestGetResponseCode_MappingFallback(t *testing.T) {
 	config.LoadedConfiguration.ResponseCode = 200
 	config.LoadedConfiguration.MethodResponseCodeMapping = []string{"GET:202", "POST:203"}
+	config.LoadedConfiguration.BuildMethodResponseCodeMap()
 
 	app := fiber.New()
 	app.Get("/test", func(c *fiber.Ctx) error {
@@ -48,6 +50,7 @@ func TestGetResponseCode_MappingFallback(t *testing.T) {
 func TestGetResponseCode_InvalidQueryParamFallsback(t *testing.T) {
 	config.LoadedConfiguration.ResponseCode = 299
 	config.LoadedConfiguration.MethodResponseCodeMapping = []string{"GET:202"}
+	config.LoadedConfiguration.BuildMethodResponseCodeMap()
 
 	app := fiber.New()
 	app.Get("/test", func(c *fiber.Ctx) error {
@@ -64,6 +67,7 @@ func TestGetResponseCode_InvalidQueryParamFallsback(t *testing.T) {
 func TestGetResponseCode_OutOfRangeQueryParamFallsback(t *testing.T) {
 	config.LoadedConfiguration.ResponseCode = 299
 	config.LoadedConfiguration.MethodResponseCodeMapping = []string{"GET:202"}
+	config.LoadedConfiguration.BuildMethodResponseCodeMap()
 
 	app := fiber.New()
 	app.Get("/test", func(c *fiber.Ctx) error {
@@ -81,6 +85,7 @@ func TestGetResponseCode_OutOfRangeQueryParamFallsback(t *testing.T) {
 func TestGetResponseCode_CaseInsensitiveVariants(t *testing.T) {
 	config.LoadedConfiguration.ResponseCode = 200
 	config.LoadedConfiguration.MethodResponseCodeMapping = []string{"GET:202"}
+	config.LoadedConfiguration.BuildMethodResponseCodeMap()
 
 	app := fiber.New()
 	app.Get("/test", func(c *fiber.Ctx) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 
 import (
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/rs/zerolog/log"
@@ -20,13 +21,14 @@ func init() {
 }
 
 type configuration struct {
-	Port                            int      `mapstructure:"port"`
-	ResponseCode                    int      `mapstructure:"responseCode"`
-	MethodResponseCodeMapping       []string `mapstructure:"methodResponseCodeMapping"`
-	ReadBufferSize                  int      `mapstructure:"readBufferSize"`
-	StoreKeyRequestHeaders          []string `mapstructure:"storeKeyRequestHeaders"`
-	SlowlorisDefaultDurationSeconds int      `mapstructure:"slowlorisDefaultDurationSeconds"`
-	SlowlorisDefaultIntervalSeconds int      `mapstructure:"slowlorisDefaultIntervalSeconds"`
+	Port                            int            `mapstructure:"port"`
+	ResponseCode                    int            `mapstructure:"responseCode"`
+	MethodResponseCodeMapping       []string       `mapstructure:"methodResponseCodeMapping"`
+	ReadBufferSize                  int            `mapstructure:"readBufferSize"`
+	StoreKeyRequestHeaders          []string       `mapstructure:"storeKeyRequestHeaders"`
+	SlowlorisDefaultDurationSeconds int            `mapstructure:"slowlorisDefaultDurationSeconds"`
+	SlowlorisDefaultIntervalSeconds int            `mapstructure:"slowlorisDefaultIntervalSeconds"`
+	MethodResponseCodeMap           map[string]int `mapstructure:"-"`
 }
 
 func setDefaults() {
@@ -58,5 +60,24 @@ func loadConfiguration() {
 
 	if err := viper.Unmarshal(&LoadedConfiguration); err != nil {
 		panic(err)
+	}
+
+	LoadedConfiguration.BuildMethodResponseCodeMap()
+}
+
+func (c *configuration) BuildMethodResponseCodeMap() {
+	c.MethodResponseCodeMap = make(map[string]int, len(c.MethodResponseCodeMapping))
+	for _, m := range c.MethodResponseCodeMapping {
+		parts := strings.SplitN(m, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		method := strings.ToUpper(strings.TrimSpace(parts[0]))
+		code, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err != nil {
+			log.Warn().Msgf("ignoring invalid method response code mapping: %s", m)
+			continue
+		}
+		c.MethodResponseCodeMap[method] = code
 	}
 }


### PR DESCRIPTION
- Add /api/v1/devnull endpoint that accepts any HTTP method, reads and discards the payload without JSON parsing, caching, or logging
- Skip logger middleware for devnull requests to avoid unnecessary I/O
- Pre-parse methodResponseCodeMapping into a map at startup for O(1) lookups instead of per-request string splitting
- Add endpoint documentation to README
- Add tests for devnull handler
- Enable StreamRequestBody globally so /api/v1/devnull skips reading
  the request body into memory entirely
- Remove unused package-level var app and init() function from api.go