### PR TITLE
feat: add configurable pod annotations

### DIFF
--- a/manifest/helm/cosmoparrot/templates/deployment.yaml
+++ b/manifest/helm/cosmoparrot/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     metadata:
       labels:
         app: {{ .Chart.Name }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/manifest/helm/cosmoparrot/values.yaml
+++ b/manifest/helm/cosmoparrot/values.yaml
@@ -39,3 +39,5 @@ cosmoparrot:
   #   - X-Correlation-ID
 
 imagePullSecrets: []
+
+podAnnotations: {}


### PR DESCRIPTION
Add configurable annotations value to the Helm Chart to specify annotations at the callsite of the Chart.