### PR TITLE
feat: make request logging configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Cosmoparrot supports configuration via environment variables and/or a configurat
 | port                        | COSMOPARROT_PORT                      | int    | 8080    | Sets the port to listen on.                                                              |
 | responseCode                | COSMOPARROT_RESPONSECODE              | int    | 200     | Enforces a specific HTTP response code. Can be used to test different consumer behavior. |
 | methodResponseCodeMapping   | COSMOPARROT_METHODRESPONSECODEMAPPING | string | ""      | Control the HTTP response code per HTTP method, for example: "POST:401"                  |
+| requestLogging              | COSMOPARROT_REQUESTLOGGING            | bool   | true    | Logs every incoming request (line, headers and body). Set to `false` to disable per-request logging, e.g. for high-throughput scenarios. |
 
 ## Endpoints
 

--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -32,8 +32,10 @@ func handleAnyRequest(c *fiber.Ctx) error {
 	if len(c.Body()) > 0 {
 		err := json.Unmarshal(c.Body(), &responseBody)
 		if err != nil {
-			log.Errorf("failed to deserialize data, error: %s", err.Error())
-			return c.SendStatus(fiber.StatusInternalServerError)
+			// A malformed body is a client error, not a server fault: respond 400
+			// and keep it at debug level so a flood of bad requests can't spam the logs.
+			log.Debugf("failed to deserialize request body, error: %s", err.Error())
+			return c.SendStatus(fiber.StatusBadRequest)
 		}
 	}
 

--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -34,7 +34,7 @@ func handleAnyRequest(c *fiber.Ctx) error {
 		if err != nil {
 			// A malformed body is a client error, not a server fault: respond 400
 			// and keep it at debug level so a flood of bad requests can't spam the logs.
-			log.Debugf("failed to deserialize request body, error: %s", err.Error())
+			log.Debugf("failed to deserialize request body, error: %v", err)
 			return c.SendStatus(fiber.StatusBadRequest)
 		}
 	}

--- a/internal/api/any_test.go
+++ b/internal/api/any_test.go
@@ -48,6 +48,19 @@ func TestHandleAnyRequest(t *testing.T) {
 	assert.Equal(t, cachedRequests[0].Body.(map[string]interface{})["message"], "test")
 }
 
+func TestHandleAnyRequest_MalformedBody(t *testing.T) {
+	app := fiber.New()
+	app.Use(handleAnyRequest)
+
+	r := httptest.NewRequest("POST", "/test", bytes.NewReader([]byte(`{not valid json`)))
+	r.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(r, -1)
+	assert.NoError(t, err)
+	// A malformed client body is a client error, not a server fault.
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
 func TestHandleAnyRequest_WithResponseDelay(t *testing.T) {
 	app := fiber.New()
 	app.Use(handleAnyRequest)

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -5,6 +5,7 @@
 package api
 
 import (
+	"cosmoparrot/internal/config"
 	"fmt"
 	"strings"
 
@@ -15,6 +16,10 @@ import (
 func getLoggerConfig() logger.Config {
 	return logger.Config{
 		Next: func(c *fiber.Ctx) bool {
+			// Skip logging entirely when request logging is disabled.
+			if !config.LoadedConfiguration.RequestLogging {
+				return true
+			}
 			return strings.HasPrefix(c.Path(), "/api/v1/devnull")
 		},
 		Format:   "${green}→ Request received:\n${reset}${time} | ${status} - ${method} ${path}\n${green}→ Request headers:${magenta}\n${custom_tag}${green}→ Request body:${cyan}\n${body}${reset}\n",

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"bytes"
+	"cosmoparrot/internal/config"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/logger"
 	"net/http"
@@ -68,4 +69,35 @@ func TestLogFormat(t *testing.T) {
 	assert.Contains(t, logOutput, "200")
 	assert.Contains(t, logOutput, `"key": "value"`)
 	assert.Contains(t, logOutput, "X-Custom-Header: [TestValue]")
+}
+
+func TestRequestLoggingDisabled(t *testing.T) {
+	// Disable request logging and restore the original value afterwards
+	original := config.LoadedConfiguration.RequestLogging
+	config.LoadedConfiguration.RequestLogging = false
+	defer func() { config.LoadedConfiguration.RequestLogging = original }()
+
+	var w byteSliceWriter
+
+	c := getLoggerConfig()
+	c.DisableColors = true
+	c.Done = func(c *fiber.Ctx, logString []byte) {
+		w.Write(logString)
+	}
+
+	app := fiber.New()
+	app.Use(logger.New(c))
+	app.Post("/test", func(c *fiber.Ctx) error {
+		return c.SendString("Hello, Fiber!")
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewBufferString(`{"key": "value"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Nothing should have been logged when request logging is disabled
+	assert.Empty(t, w.b)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type configuration struct {
 	Port                            int            `mapstructure:"port"`
 	ResponseCode                    int            `mapstructure:"responseCode"`
 	MethodResponseCodeMapping       []string       `mapstructure:"methodResponseCodeMapping"`
+	RequestLogging                  bool           `mapstructure:"requestLogging"`
 	ReadBufferSize                  int            `mapstructure:"readBufferSize"`
 	StoreKeyRequestHeaders          []string       `mapstructure:"storeKeyRequestHeaders"`
 	SlowlorisDefaultDurationSeconds int            `mapstructure:"slowlorisDefaultDurationSeconds"`
@@ -35,6 +36,7 @@ func setDefaults() {
 	viper.SetDefault("port", 8080)
 	viper.SetDefault("responseCode", 200)
 	viper.SetDefault("methodResponseCodeMapping", []string{})
+	viper.SetDefault("requestLogging", true)
 	viper.SetDefault("readBufferSize", 4096)
 	viper.SetDefault("storeKeyRequestHeaders", []string{"x-request-key"})
 	viper.SetDefault("slowlorisDefaultDurationSeconds", 15)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,7 +20,23 @@ func TestSetDefaults(t *testing.T) {
 	assert.Equal(t, 8080, viper.GetInt("port"))
 	assert.Equal(t, 200, viper.GetInt("responseCode"))
 	assert.Equal(t, []string{}, viper.GetStringSlice("methodResponseCodeMapping"))
+	assert.Equal(t, true, viper.GetBool("requestLogging"))
 	assert.Equal(t, []string{"x-request-key"}, viper.GetStringSlice("storeKeyRequestHeaders"))
+}
+
+func TestRequestLoggingEnvironmentOverride(t *testing.T) {
+	// Reset Viper to ensure clean state
+	viper.Reset()
+	setDefaults()
+
+	os.Setenv("COSMOPARROT_REQUESTLOGGING", "false")
+
+	loadConfiguration()
+
+	assert.Equal(t, false, LoadedConfiguration.RequestLogging)
+
+	// Cleanup
+	os.Unsetenv("COSMOPARROT_REQUESTLOGGING")
 }
 
 func TestEnvironmentVariableOverride(t *testing.T) {

--- a/manifest/helm/cosmoparrot/templates/deployment.yaml
+++ b/manifest/helm/cosmoparrot/templates/deployment.yaml
@@ -40,6 +40,8 @@ spec:
           env:
             - name: COSMOPARROT_PORT
               value: "{{ .Values.service.port }}"
+            - name: COSMOPARROT_REQUESTLOGGING
+              value: "{{ .Values.cosmoparrot.requestLogging }}"
             - name: COSMOPARROT_STOREKEYREQUESTHEADERS
               value: "{{ join "," .Values.cosmoparrot.storeKeyRequestHeaders }}"
           securityContext:

--- a/manifest/helm/cosmoparrot/values.yaml
+++ b/manifest/helm/cosmoparrot/values.yaml
@@ -32,6 +32,9 @@ resources:
     memory: "256Mi"
 
 cosmoparrot:
+  # Log every incoming request (line, headers and body).
+  # Set to false to disable per-request logging.
+  requestLogging: true
   storeKeyRequestHeaders: []
   # Example:
   # storeKeyRequestHeaders:


### PR DESCRIPTION
## Summary

Request logging was previously unconditional — Fiber's `logger` middleware logged every request (line, all headers, full body), with only `/api/v1/devnull` hardcoded to skip. There was no way to turn it off.

This PR makes per-request logging configurable and fixes a related log-spam issue.

### Changes

- **Configurable request logging.** New `requestLogging` option (env `COSMOPARROT_REQUESTLOGGING`, config key `requestLogging`), defaulting to `true` so existing behavior is unchanged. When set to `false`, the access logger is skipped entirely. The existing `/api/v1/devnull` skip is preserved.
- **Malformed body is now a client error.** A request body that fails JSON unmarshal previously logged at **error** level and returned **500**. It now logs at **debug** level and returns **400 Bad Request** — semantically correct, and a flood of bad requests can no longer spam the logs.
- Wired the new option through the README config table, Helm `values.yaml`, and the Helm deployment template.

### How to disable request logging

- Env: `COSMOPARROT_REQUESTLOGGING=false`
- `config.yml`: `requestLogging: false`
- Helm: `--set cosmoparrot.requestLogging=false`

Genuine server faults (corrupt cached data, fatal startup errors) still log at error level / return 500 — untouched.

### Tests

- `config`: default-is-`true` assertion + env-override-to-`false`.
- `api`: `TestRequestLoggingDisabled` (nothing logged when off) and `TestHandleAnyRequest_MalformedBody` (400 on bad body).

`go build ./...` passes, full suite green, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)