### PR TITLE
feat: add responseSize parameter and implement case-insensitive query handling

### DIFF
--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -9,11 +9,12 @@ import (
 	"cosmoparrot/internal/config"
 	"cosmoparrot/internal/utils"
 	"encoding/json"
+	"math/rand"
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
-	"math/rand"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/log"
@@ -24,7 +25,7 @@ const maxResponseDelayMs = 60000
 const maxResponseSize = 10_000_000
 const maxResponseSizePaddingWindowSize = 4096 // How often the padding is shifted before wrapping around
 var paddingSource = newRandomString(maxResponseSize + maxResponseSizePaddingWindowSize)
-var paddingOffset int
+var paddingOffset atomic.Int64
 
 // newRandomString builds a random string
 func newRandomString(length int) string {
@@ -98,8 +99,8 @@ func handleAnyRequest(c *fiber.Ctx) error {
 	}
 
 	if size := getResponseSize(c); size > 0 {
-		paddingOffset = (paddingOffset + 1) % maxResponseSizePaddingWindowSize
-		reqData.Padding = paddingSource[paddingOffset : paddingOffset+size]
+		offset := int(paddingOffset.Add(1) % maxResponseSizePaddingWindowSize)
+		reqData.Padding = paddingSource[offset : offset+size]
 	}
 
 	return c.Status(getResponseCode(c)).JSON(reqData)

--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"math/rand"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/log"
@@ -20,6 +21,20 @@ import (
 )
 
 const maxResponseDelayMs = 60000
+const maxResponseSize = 10_000_000
+const maxResponseSizePaddingWindowSize = 4096 // How often the padding is shifted before wrapping around
+var paddingSource = newRandomString(maxResponseSize + maxResponseSizePaddingWindowSize)
+var paddingOffset int
+
+// newRandomString builds a random string
+func newRandomString(length int) string {
+	const characters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = characters[rand.Intn(len(characters))]
+	}
+	return string(b)
+}
 
 func handleAnyRequest(c *fiber.Ctx) error {
 	userAgent := c.Get("User-Agent")
@@ -82,6 +97,11 @@ func handleAnyRequest(c *fiber.Ctx) error {
 		time.Sleep(delay)
 	}
 
+	if size := getResponseSize(c); size > 0 {
+		paddingOffset = (paddingOffset + 1) % maxResponseSizePaddingWindowSize
+		reqData.Padding = paddingSource[paddingOffset : paddingOffset+size]
+	}
+
 	return c.Status(getResponseCode(c)).JSON(reqData)
 }
 
@@ -119,9 +139,19 @@ func setResponseHeaders(c *fiber.Ctx) {
 	c.Set("Current-Control", "max-age=0, must-revalidate")
 }
 
+// queryCaseInsensitive returns the value of the query parameter whose name
+// matches key case-insensitively, or "" if none is present.
+func queryCaseInsensitive(c *fiber.Ctx, key string) string {
+	for k, v := range c.Queries() {
+		if strings.EqualFold(k, key) {
+			return v
+		}
+	}
+	return ""
+}
+
 func getResponseCode(c *fiber.Ctx) int {
-	// Simple, case-sensitive query-parameter override. Only `responseCode` is accepted.
-	if rc := c.Query("responseCode"); rc != "" {
+	if rc := queryCaseInsensitive(c, "responseCode"); rc != "" {
 		if code, err := strconv.Atoi(strings.TrimSpace(rc)); err == nil && code >= 100 && code <= 599 {
 			return code
 		}
@@ -139,7 +169,7 @@ func getResponseCode(c *fiber.Ctx) int {
 // and returns the corresponding time.Duration. Returns 0 for missing, non-integer,
 // negative, or out-of-range (>60000 ms) values.
 func getResponseDelay(c *fiber.Ctx) time.Duration {
-	raw := c.Query("responseDelay")
+	raw := queryCaseInsensitive(c, "responseDelay")
 	if raw == "" {
 		return 0
 	}
@@ -150,4 +180,21 @@ func getResponseDelay(c *fiber.Ctx) time.Duration {
 	}
 
 	return time.Duration(ms) * time.Millisecond
+}
+
+// getResponseSize reads the optional "responseSize" query parameter (bytes)
+// and returns the corresponding integer. Returns 0 for missing, non-integer,
+// negative, or out-of-range (> 100 MB) values.
+func getResponseSize(c *fiber.Ctx) int {
+	raw := queryCaseInsensitive(c, "responseSize")
+	if raw == "" {
+		return 0
+	}
+
+	ms, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || ms < 0 || ms > maxResponseSize {
+		return 0
+	}
+
+	return ms
 }

--- a/internal/api/getresponsecode_test.go
+++ b/internal/api/getresponsecode_test.go
@@ -81,7 +81,8 @@ func TestGetResponseCode_OutOfRangeQueryParamFallsback(t *testing.T) {
 	assert.Equal(t, 202, resp.StatusCode)
 }
 
-// New test: case-insensitive and variant recognition for responseCode
+// Case sensitivity should be ignored for query parameters
+// "-" and "_" should NOT be recognized
 func TestGetResponseCode_CaseInsensitiveVariants(t *testing.T) {
 	config.LoadedConfiguration.ResponseCode = 200
 	config.LoadedConfiguration.MethodResponseCodeMapping = []string{"GET:202"}
@@ -93,16 +94,17 @@ func TestGetResponseCode_CaseInsensitiveVariants(t *testing.T) {
 		return c.SendStatus(code)
 	})
 
-	// Non-exact variants should NOT be recognized anymore and therefore fall back to mapping (202).
 	cases := []struct {
 		url  string
 		want int
 	}{
 		{"/test?response_code=205", 202},
-		{"/test?RESPONSECODE=206", 202},
-		{"/test?Response-Code=207", 202},
+		{"/test?Response-Code=206", 202},
 		// exact match should still work
-		{"/test?responseCode=205", 205},
+		{"/test?responsecode=207", 207},
+		{"/test?rEspoNsecOde=208", 208},
+		{"/test?RESPONSECODE=209", 209},
+		{"/test?responseCode=210", 210},
 	}
 
 	for _, tc := range cases {

--- a/internal/api/getresponsesize_test.go
+++ b/internal/api/getresponsesize_test.go
@@ -8,132 +8,131 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetResponseDelay_ValidValue(t *testing.T) {
+func TestGetResponseSize_ValidValue(t *testing.T) {
 	app := fiber.New()
-	var result time.Duration
+	var result int
 	app.Get("/test", func(c *fiber.Ctx) error {
-		result = getResponseDelay(c)
+		result = getResponseSize(c)
 		return c.SendStatus(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/test?responseDelay=500", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?responseSize=500", nil)
 	resp, err := app.Test(req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, 500*time.Millisecond, result)
+	assert.Equal(t, 500, result)
 }
 
-func TestGetResponseDelay_MissingParam(t *testing.T) {
+func TestGetResponseSize_MissingParam(t *testing.T) {
 	app := fiber.New()
-	var result time.Duration
+	var result int
 	app.Get("/test", func(c *fiber.Ctx) error {
-		result = getResponseDelay(c)
+		result = getResponseSize(c)
 		return c.SendStatus(http.StatusOK)
 	})
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
 	resp, _ := app.Test(req)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, time.Duration(0), result)
+	assert.Equal(t, 0, result)
 }
 
-func TestGetResponseDelay_NonInteger(t *testing.T) {
+func TestGetResponseSize_NonInteger(t *testing.T) {
 	app := fiber.New()
-	var result time.Duration
+	var result int
 	app.Get("/test", func(c *fiber.Ctx) error {
-		result = getResponseDelay(c)
+		result = getResponseSize(c)
 		return c.SendStatus(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/test?responseDelay=abc", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?responseSize=abc", nil)
 	resp, _ := app.Test(req)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, time.Duration(0), result)
+	assert.Equal(t, 0, result)
 }
 
-func TestGetResponseDelay_NegativeValue(t *testing.T) {
+func TestGetResponseSize_NegativeValue(t *testing.T) {
 	app := fiber.New()
-	var result time.Duration
+	var result int
 	app.Get("/test", func(c *fiber.Ctx) error {
-		result = getResponseDelay(c)
+		result = getResponseSize(c)
 		return c.SendStatus(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/test?responseDelay=-100", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?responseSize=-100", nil)
 	resp, _ := app.Test(req)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, time.Duration(0), result)
+	assert.Equal(t, 0, result)
 }
 
-func TestGetResponseDelay_ExceedsMax(t *testing.T) {
+func TestGetResponseSize_ExceedsMax(t *testing.T) {
 	app := fiber.New()
-	var result time.Duration
+	var result int
 	app.Get("/test", func(c *fiber.Ctx) error {
-		result = getResponseDelay(c)
+		result = getResponseSize(c)
 		return c.SendStatus(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/test?responseDelay=60001", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?responseSize=10000001", nil)
 	resp, _ := app.Test(req)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, time.Duration(0), result)
+	assert.Equal(t, 0, result)
 }
 
-func TestGetResponseDelay_BoundaryMax(t *testing.T) {
+func TestGetResponseSize_BoundaryMax(t *testing.T) {
 	app := fiber.New()
-	var result time.Duration
+	var result int
 	app.Get("/test", func(c *fiber.Ctx) error {
-		result = getResponseDelay(c)
+		result = getResponseSize(c)
 		return c.SendStatus(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/test?responseDelay=60000", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?responseSize=10000000", nil)
 	resp, _ := app.Test(req)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, 60*time.Second, result)
+	assert.Equal(t, maxResponseSize, result)
 }
 
-func TestGetResponseDelay_Zero(t *testing.T) {
+func TestGetResponseSize_Zero(t *testing.T) {
 	app := fiber.New()
-	var result time.Duration
+	var result int
 	app.Get("/test", func(c *fiber.Ctx) error {
-		result = getResponseDelay(c)
+		result = getResponseSize(c)
 		return c.SendStatus(http.StatusOK)
 	})
 
-	req := httptest.NewRequest(http.MethodGet, "/test?responseDelay=0", nil)
+	req := httptest.NewRequest(http.MethodGet, "/test?responseSize=0", nil)
 	resp, _ := app.Test(req)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, time.Duration(0), result)
+	assert.Equal(t, 0, result)
 }
 
 // Case sensitivity should be ignored for query parameters
 // "-" and "_" should NOT be recognized
-func TestGetResponseDelay_CaseInsensitiveVariants(t *testing.T) {
+func TestGetResponseSize_CaseInsensitiveVariants(t *testing.T) {
 	app := fiber.New()
-	var result time.Duration
+	var result int
 	app.Get("/test", func(c *fiber.Ctx) error {
-		result = getResponseDelay(c)
+		result = getResponseSize(c)
 		return c.SendStatus(http.StatusOK)
 	})
 
 	cases := []struct {
 		url  string
-		want time.Duration
+		want int
 	}{
-		{"/test?response_delay=500", 0},
-		{"/test?Response-Delay=500", 0},
+		{"/test?response_size=500", 0},
+		{"/test?Response-Size=500", 0},
 		// exact match should work
-		{"/test?responsedelay=500", 500 * time.Millisecond},
-		{"/test?reSpoNseDelay=500", 500 * time.Millisecond},
-		{"/test?RESPONSEDELAY=500", 500 * time.Millisecond},
-		{"/test?responseDelay=500", 500 * time.Millisecond},
+		{"/test?reSpoNsesIze=500", 500},
+		{"/test?responsesize=500", 500},
+		{"/test?RESPONSESIZE=500", 500},
+		{"/test?responseSize=500", 500},
 	}
 
 	for _, tc := range cases {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -12,5 +12,5 @@ type request struct {
 	Method  string              `json:"method"`
 	Headers map[string][]string `json:"headers,omitempty"`
 	Body    any                 `json:"body,omitempty"`
-	Padding string              `json:"padding"`
+	Padding string              `json:"padding,omitempty"`
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -12,4 +12,5 @@ type request struct {
 	Method  string              `json:"method"`
 	Headers map[string][]string `json:"headers,omitempty"`
 	Body    any                 `json:"body,omitempty"`
+	Padding string              `json:"padding"`
 }


### PR DESCRIPTION
This PR adds support for response size simulation and improves query parameter handling.

Changes made:
- Added responseSize query parameter to control response payload padding to enable testing with realistic payload size
- Added case-insensitive query matching for responseCode, responseDelay, and responseSize
- Added tests for responseSize validation
- Updated tests for case-insensivie