### PR TITLE
feat: add mirrorBody query parameter to disable response body mirroring

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Cosmoparrot supports configuration via environment variables and/or a configurat
 ### Echo (catch-all)
 Any request that does not match a specific route is handled by the echo handler. It mirrors the request back as a JSON response including path, method, headers, and body.
 
+- Supports `?mirrorBody=false` to suppress echoing the request body back in the response body (defaults to `true`). The request body is still parsed and stored if a store key header is configured.
+
 ### `/api/v1/devnull`
 A high-performance sink endpoint that accepts any HTTP method. It reads and discards the request payload without parsing, logging, or storing anything — making it safe for sustained high-throughput scenarios with no risk of OOM.
 

--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -94,6 +94,12 @@ func handleAnyRequest(c *fiber.Ctx) error {
 		cache.Current.Set(key, string(jsonData), go_cache.DefaultExpiration)
 	}
 
+	// suppress the echoed request body if the client opted out; the stored
+	// copy above intentionally keeps the full body for later inspection.
+	if !getMirrorBody(c) {
+		reqData.Body = nil
+	}
+
 	if delay := getResponseDelay(c); delay > 0 {
 		time.Sleep(delay)
 	}
@@ -149,6 +155,24 @@ func queryCaseInsensitive(c *fiber.Ctx, key string) string {
 		}
 	}
 	return ""
+}
+
+// getMirrorBody reads the optional "mirrorBody" query parameter. Body mirroring
+// is enabled by default; it is only disabled when the parameter is explicitly set
+// to a false-y value ("false", "0", "f"). Missing or unparsable values keep the
+// default (true), so the request body is echoed back in the response body.
+func getMirrorBody(c *fiber.Ctx) bool {
+	raw := queryCaseInsensitive(c, "mirrorBody")
+	if raw == "" {
+		return true
+	}
+
+	enabled, err := strconv.ParseBool(strings.TrimSpace(raw))
+	if err != nil {
+		return true
+	}
+
+	return enabled
 }
 
 func getResponseCode(c *fiber.Ctx) int {

--- a/internal/api/any_test.go
+++ b/internal/api/any_test.go
@@ -48,6 +48,36 @@ func TestHandleAnyRequest(t *testing.T) {
 	assert.Equal(t, cachedRequests[0].Body.(map[string]interface{})["message"], "test")
 }
 
+func TestHandleAnyRequest_MirrorBodyDisabled(t *testing.T) {
+	app := fiber.New()
+	app.Use(handleAnyRequest)
+
+	requestBody := []byte(`{"message": "test"}`)
+	r := httptest.NewRequest("POST", "/test?mirrorBody=false", bytes.NewReader(requestBody))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("X-Request-Key", "no-mirror-key")
+
+	resp, err := app.Test(r, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var responseData map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&responseData)
+	assert.NoError(t, err)
+	assert.Equal(t, "/test", responseData["path"])
+	assert.Equal(t, "POST", responseData["method"])
+	// body must NOT be mirrored back in the response
+	_, hasBody := responseData["body"]
+	assert.False(t, hasBody, "response body should be omitted when mirrorBody=false")
+
+	// the stored copy still keeps the full request body
+	var cachedRequests []*request
+	jsonStr, _ := cache.Current.Get("no-mirror-key")
+	err = json.Unmarshal([]byte(jsonStr.(string)), &cachedRequests)
+	assert.NoError(t, err)
+	assert.Equal(t, cachedRequests[0].Body.(map[string]interface{})["message"], "test")
+}
+
 func TestHandleAnyRequest_MalformedBody(t *testing.T) {
 	app := fiber.New()
 	app.Use(handleAnyRequest)

--- a/internal/api/getmirrorbody_test.go
+++ b/internal/api/getmirrorbody_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMirrorBody_MissingParamDefaultsTrue(t *testing.T) {
+	app := fiber.New()
+	var result bool
+	app.Get("/test", func(c *fiber.Ctx) error {
+		result = getMirrorBody(c)
+		return c.SendStatus(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, result)
+}
+
+func TestGetMirrorBody_InvalidValueDefaultsTrue(t *testing.T) {
+	app := fiber.New()
+	var result bool
+	app.Get("/test", func(c *fiber.Ctx) error {
+		result = getMirrorBody(c)
+		return c.SendStatus(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/test?mirrorBody=maybe", nil)
+	resp, _ := app.Test(req)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.True(t, result)
+}
+
+func TestGetMirrorBody_ExplicitValues(t *testing.T) {
+	app := fiber.New()
+	var result bool
+	app.Get("/test", func(c *fiber.Ctx) error {
+		result = getMirrorBody(c)
+		return c.SendStatus(http.StatusOK)
+	})
+
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"/test?mirrorBody=false", false},
+		{"/test?mirrorBody=0", false},
+		{"/test?mirrorBody=f", false},
+		{"/test?mirrorBody=FALSE", false},
+		{"/test?mirrorBody=true", true},
+		{"/test?mirrorBody=1", true},
+		// case-insensitive param name, "-"/"_" variants are NOT recognized
+		{"/test?MIRRORBODY=false", false},
+		{"/test?mirror_body=false", true},
+		{"/test?mirror-body=false", true},
+	}
+
+	for _, tc := range cases {
+		result = true
+		req := httptest.NewRequest(http.MethodGet, tc.url, nil)
+		resp, _ := app.Test(req)
+		assert.Equal(t, http.StatusOK, resp.StatusCode, "url: %s", tc.url)
+		assert.Equal(t, tc.want, result, "url: %s", tc.url)
+	}
+}


### PR DESCRIPTION
## Summary

The echo catch-all endpoint mirrors the request body back in the response body. This adds an optional `mirrorBody` query parameter (defaults to `true`) to suppress that echo per request.

- `?mirrorBody=false` (or `0`/`f`) omits the `body` field from the response.
- Missing or unparsable values keep the default (`true`).
- Parameter name is matched case-insensitively, consistent with `responseCode`/`responseDelay`/`responseSize`.
- The request body is still parsed and stored under a configured store key header — only the response echo is affected.

## Changes

- `internal/api/any.go`: new `getMirrorBody` helper; strip `reqData.Body` from the response (after the store write) when disabled.
- `internal/api/getmirrorbody_test.go`: unit tests (default, invalid, explicit values, case-insensitivity).
- `internal/api/any_test.go`: e2e test asserting the response omits `body` while the store retains it.
- `README.md`: documented `?mirrorBody=false` under the Echo endpoint.

## Usage

```
POST /anything?mirrorBody=false
```
Response contains `time`/`path`/`method`/`headers` but no `body`.