### PR TITLE
fix: reduce memory usage to prevent OOM kills under load

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ Cosmoparrot supports configuration via environment variables and/or a configurat
 | port                        | COSMOPARROT_PORT                      | int    | 8080    | Sets the port to listen on.                                                              |
 | responseCode                | COSMOPARROT_RESPONSECODE              | int    | 200     | Enforces a specific HTTP response code. Can be used to test different consumer behavior. |
 | methodResponseCodeMapping   | COSMOPARROT_METHODRESPONSECODEMAPPING | string | ""      | Control the HTTP response code per HTTP method, for example: "POST:401"                  |
-| requestLogging              | COSMOPARROT_REQUESTLOGGING            | bool   | true    | Logs every incoming request (line, headers and body). Set to `false` to disable per-request logging, e.g. for high-throughput scenarios. |
+| requestLogging              | COSMOPARROT_REQUESTLOGGING            | bool   | true    | Logs every incoming request (request line and headers). Set to `false` to disable per-request logging, e.g. for high-throughput scenarios. Request bodies are never logged. |
+
+> **Memory (GOMEMLIMIT):** On startup Cosmoparrot detects the container's cgroup
+> memory limit and sets a Go soft memory limit (`GOMEMLIMIT`) at 90% of it. This
+> makes the garbage collector run more aggressively as memory fills up, which
+> prevents the pod from being OOM-killed under bursty load. Set the `GOMEMLIMIT`
+> environment variable explicitly to override the auto-detected value.
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,12 @@ Cosmoparrot supports configuration via environment variables and/or a configurat
 ### Echo (catch-all)
 Any request that does not match a specific route is handled by the echo handler. It mirrors the request back as a JSON response including path, method, headers, and body.
 
-- Supports `?mirrorBody=false` to suppress echoing the request body back in the response body (defaults to `true`). The request body is still parsed and stored if a store key header is configured.
+- Supports `?mirrorBody=false` to suppress echoing the request body back in the response body (defaults to `true`). When disabled, the request body is not read at all — it is neither echoed nor stored, and is not validated (no `400` on malformed JSON). This keeps large payloads off-heap.
+
+### Request store
+The echo handler can record incoming requests in an in-memory cache so they can be retrieved later via `/api/v1/requests` and `/api/v1/requests/:key` (useful for asserting, in tests, what a component sent). A request is stored only when it carries one of the headers listed in `storeKeyRequestHeaders`, keyed by that header's value; entries expire after 1 hour.
+
+> **The store is disabled when `storeKeyRequestHeaders` is empty** (the Helm default) — no separate toggle is needed. Avoid configuring a header that is unique per request (e.g. a trace id such as `X-B3-Traceid`): every request then creates its own entry and the cache grows unbounded until it OOMs. Use a coarse key (or leave it empty) for high-throughput/load scenarios.
 
 ### `/api/v1/devnull`
 A high-performance sink endpoint that accepts any HTTP method. It reads and discards the request payload without parsing, logging, or storing anything — making it safe for sustained high-throughput scenarios with no risk of OOM.

--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -43,16 +43,14 @@ func handleAnyRequest(c *fiber.Ctx) error {
 		return c.Next()
 	}
 
-	var responseBody any
+	var responseBody json.RawMessage
 
-	if len(c.Body()) > 0 {
-		err := json.Unmarshal(c.Body(), &responseBody)
-		if err != nil {
-			// A malformed body is a client error, not a server fault: respond 400
-			// and keep it at debug level so a flood of bad requests can't spam the logs.
-			log.Debugf("failed to deserialize request body, error: %v", err)
+	if body := c.Body(); len(body) > 0 {
+		if !json.Valid(body) {
+			log.Debug("failed to deserialize request body: invalid JSON")
 			return c.SendStatus(fiber.StatusBadRequest)
 		}
+		responseBody = body
 	}
 
 	setResponseHeaders(c)

--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -43,14 +43,17 @@ func handleAnyRequest(c *fiber.Ctx) error {
 		return c.Next()
 	}
 
+	// The request body is only read when it is echoed back.
 	var responseBody json.RawMessage
 
-	if body := c.Body(); len(body) > 0 {
-		if !json.Valid(body) {
-			log.Debug("failed to deserialize request body: invalid JSON")
-			return c.SendStatus(fiber.StatusBadRequest)
+	if getMirrorBody(c) {
+		if body := c.Body(); len(body) > 0 {
+			if !json.Valid(body) {
+				log.Debug("failed to deserialize request body: invalid JSON")
+				return c.SendStatus(fiber.StatusBadRequest)
+			}
+			responseBody = body
 		}
-		responseBody = body
 	}
 
 	setResponseHeaders(c)
@@ -90,12 +93,6 @@ func handleAnyRequest(c *fiber.Ctx) error {
 
 		// write to store
 		cache.Current.Set(key, string(jsonData), go_cache.DefaultExpiration)
-	}
-
-	// suppress the echoed request body if the client opted out; the stored
-	// copy above intentionally keeps the full body for later inspection.
-	if !getMirrorBody(c) {
-		reqData.Body = nil
 	}
 
 	if delay := getResponseDelay(c); delay > 0 {

--- a/internal/api/any.go
+++ b/internal/api/any.go
@@ -9,6 +9,7 @@ import (
 	"cosmoparrot/internal/config"
 	"cosmoparrot/internal/utils"
 	"encoding/json"
+	"io"
 	"math/rand"
 	"slices"
 	"strconv"
@@ -54,6 +55,9 @@ func handleAnyRequest(c *fiber.Ctx) error {
 			}
 			responseBody = body
 		}
+	} else if stream := c.Context().RequestBodyStream(); stream != nil {
+		// drain the streamed body so the connection can be reused
+		_, _ = io.Copy(io.Discard, stream)
 	}
 
 	setResponseHeaders(c)

--- a/internal/api/any_test.go
+++ b/internal/api/any_test.go
@@ -94,6 +94,29 @@ func TestHandleAnyRequest_MalformedBody(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestHandleAnyRequest_DrainsStreamedBodyWhenNotMirroring(t *testing.T) {
+	app := fiber.New(fiber.Config{StreamRequestBody: true})
+	app.Use(handleAnyRequest)
+
+	// A large body forces fasthttp to expose it as a stream; with
+	// mirrorBody=false the handler must drain it so the request still
+	// completes cleanly instead of leaving the body unread.
+	largeBody := bytes.Repeat([]byte("a"), 5*1024*1024)
+	r := httptest.NewRequest("POST", "/test?mirrorBody=false", bytes.NewReader(largeBody))
+	r.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := app.Test(r, -1)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var responseData map[string]interface{}
+	err = json.NewDecoder(resp.Body).Decode(&responseData)
+	assert.NoError(t, err)
+	assert.Equal(t, "/test", responseData["path"])
+	_, hasBody := responseData["body"]
+	assert.False(t, hasBody)
+}
+
 func TestHandleAnyRequest_WithResponseDelay(t *testing.T) {
 	app := fiber.New()
 	app.Use(handleAnyRequest)

--- a/internal/api/any_test.go
+++ b/internal/api/any_test.go
@@ -37,6 +37,8 @@ func TestHandleAnyRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "/test", responseData["path"])
 	assert.Equal(t, "POST", responseData["method"])
+	// the request body is mirrored verbatim into the response body
+	assert.Equal(t, map[string]interface{}{"message": "test"}, responseData["body"])
 
 	var cachedRequests []*request
 	jsonStr, _ := cache.Current.Get("test-key")
@@ -45,7 +47,7 @@ func TestHandleAnyRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, cachedRequests[0].Path, "/test")
 	assert.Equal(t, cachedRequests[0].Method, "POST")
-	assert.Equal(t, cachedRequests[0].Body.(map[string]interface{})["message"], "test")
+	assert.JSONEq(t, `{"message": "test"}`, string(cachedRequests[0].Body))
 }
 
 func TestHandleAnyRequest_MirrorBodyDisabled(t *testing.T) {
@@ -75,7 +77,7 @@ func TestHandleAnyRequest_MirrorBodyDisabled(t *testing.T) {
 	jsonStr, _ := cache.Current.Get("no-mirror-key")
 	err = json.Unmarshal([]byte(jsonStr.(string)), &cachedRequests)
 	assert.NoError(t, err)
-	assert.Equal(t, cachedRequests[0].Body.(map[string]interface{})["message"], "test")
+	assert.JSONEq(t, `{"message": "test"}`, string(cachedRequests[0].Body))
 }
 
 func TestHandleAnyRequest_MalformedBody(t *testing.T) {

--- a/internal/api/any_test.go
+++ b/internal/api/any_test.go
@@ -72,12 +72,13 @@ func TestHandleAnyRequest_MirrorBodyDisabled(t *testing.T) {
 	_, hasBody := responseData["body"]
 	assert.False(t, hasBody, "response body should be omitted when mirrorBody=false")
 
-	// the stored copy still keeps the full request body
+	// the request is recorded without its body when mirroring is disabled
 	var cachedRequests []*request
 	jsonStr, _ := cache.Current.Get("no-mirror-key")
 	err = json.Unmarshal([]byte(jsonStr.(string)), &cachedRequests)
 	assert.NoError(t, err)
-	assert.JSONEq(t, `{"message": "test"}`, string(cachedRequests[0].Body))
+	assert.Equal(t, "/test", cachedRequests[0].Path)
+	assert.Nil(t, cachedRequests[0].Body)
 }
 
 func TestHandleAnyRequest_MalformedBody(t *testing.T) {

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -22,7 +22,8 @@ func getLoggerConfig() logger.Config {
 			}
 			return strings.HasPrefix(c.Path(), "/api/v1/devnull")
 		},
-		Format:   "${green}→ Request received:\n${reset}${time} | ${status} - ${method} ${path}\n${green}→ Request headers:${magenta}\n${custom_tag}${green}→ Request body:${cyan}\n${body}${reset}\n",
+		// The request body is intentionally not logged.
+		Format:   "${green}→ Request received:\n${reset}${time} | ${status} - ${method} ${path}\n${green}→ Request headers:${magenta}\n${custom_tag}${reset}\n",
 		TimeZone: "UTC",
 		CustomTags: map[string]logger.LogFunc{
 			"custom_tag": func(output logger.Buffer, c *fiber.Ctx, data *logger.Data, extraParam string) (int, error) {

--- a/internal/api/common_test.go
+++ b/internal/api/common_test.go
@@ -67,7 +67,8 @@ func TestLogFormat(t *testing.T) {
 	assert.Contains(t, logOutput, "→ Request received:")
 	assert.Contains(t, logOutput, "POST /test")
 	assert.Contains(t, logOutput, "200")
-	assert.Contains(t, logOutput, `"key": "value"`)
+	// The request body must not be logged.
+	assert.NotContains(t, logOutput, `"key": "value"`)
 	assert.Contains(t, logOutput, "X-Custom-Header: [TestValue]")
 }
 

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -4,13 +4,16 @@
 
 package api
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 type request struct {
 	Time    time.Time           `json:"time"`
 	Path    string              `json:"path"`
 	Method  string              `json:"method"`
 	Headers map[string][]string `json:"headers,omitempty"`
-	Body    any                 `json:"body,omitempty"`
+	Body    json.RawMessage     `json:"body,omitempty"`
 	Padding string              `json:"padding,omitempty"`
 }

--- a/internal/memlimit/memlimit.go
+++ b/internal/memlimit/memlimit.go
@@ -1,0 +1,70 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package memlimit derives the Go soft memory limit (GOMEMLIMIT) from the
+// container's cgroup memory limit.
+package memlimit
+
+import (
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	"github.com/gofiber/fiber/v2/log"
+)
+
+const (
+	cgroupV2Max = "/sys/fs/cgroup/memory.max"
+	cgroupV1Max = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+)
+
+const reserveRatio = 0.9
+
+const cgroupV1Unlimited = int64(1) << 62
+
+// Configure sets GOMEMLIMIT from the container's cgroup memory limit unless it
+// has already been provided explicitly via the environment.
+func Configure() {
+	if _, ok := os.LookupEnv("GOMEMLIMIT"); ok {
+		return
+	}
+
+	limit, ok := detectCgroupLimit()
+	if !ok {
+		return
+	}
+
+	soft := int64(float64(limit) * reserveRatio)
+	debug.SetMemoryLimit(soft)
+	log.Infof("GOMEMLIMIT set to %d bytes (%.0f%% of cgroup limit %d bytes)", soft, reserveRatio*100, limit)
+}
+
+func detectCgroupLimit() (int64, bool) {
+	for _, path := range []string{cgroupV2Max, cgroupV1Max} {
+		if v, ok := readLimit(path); ok {
+			return v, true
+		}
+	}
+	return 0, false
+}
+
+func readLimit(path string) (int64, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+
+	s := strings.TrimSpace(string(data))
+	if s == "" || s == "max" {
+		return 0, false
+	}
+
+	v, err := strconv.ParseInt(s, 10, 64)
+	if err != nil || v <= 0 || v >= cgroupV1Unlimited {
+		return 0, false
+	}
+
+	return v, true
+}

--- a/internal/memlimit/memlimit_test.go
+++ b/internal/memlimit/memlimit_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Deutsche Telekom IT GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package memlimit
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "limit")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp file: %v", err)
+	}
+	return path
+}
+
+func TestReadLimit_ValidValue(t *testing.T) {
+	v, ok := readLimit(writeTemp(t, "536870912\n"))
+	assert.True(t, ok)
+	assert.Equal(t, int64(536870912), v)
+}
+
+func TestReadLimit_CgroupV2Max(t *testing.T) {
+	_, ok := readLimit(writeTemp(t, "max\n"))
+	assert.False(t, ok)
+}
+
+func TestReadLimit_Empty(t *testing.T) {
+	_, ok := readLimit(writeTemp(t, ""))
+	assert.False(t, ok)
+}
+
+func TestReadLimit_NonNumeric(t *testing.T) {
+	_, ok := readLimit(writeTemp(t, "not-a-number"))
+	assert.False(t, ok)
+}
+
+func TestReadLimit_ZeroOrNegative(t *testing.T) {
+	_, ok := readLimit(writeTemp(t, "0"))
+	assert.False(t, ok)
+
+	_, ok = readLimit(writeTemp(t, "-1"))
+	assert.False(t, ok)
+}
+
+func TestReadLimit_CgroupV1Unlimited(t *testing.T) {
+	// cgroup v1 reports a huge sentinel when no limit is set.
+	_, ok := readLimit(writeTemp(t, "9223372036854771712"))
+	assert.False(t, ok)
+}
+
+func TestReadLimit_MissingFile(t *testing.T) {
+	_, ok := readLimit(filepath.Join(t.TempDir(), "does-not-exist"))
+	assert.False(t, ok)
+}
+
+func TestConfigure_RespectsExplicitEnv(t *testing.T) {
+	// When GOMEMLIMIT is set, Configure must not override it.
+	t.Setenv("GOMEMLIMIT", "128MiB")
+	assert.NotPanics(t, Configure)
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"cosmoparrot/internal/api"
+	"cosmoparrot/internal/memlimit"
 	"embed"
 	_ "embed"
 )
@@ -14,5 +15,6 @@ import (
 var webDir embed.FS
 
 func main() {
+	memlimit.Configure()
 	api.Listen(webDir)
 }


### PR DESCRIPTION
## Summary

Load testing with large payloads OOM-killed pods despite many replicas at a 512 MiB limit. This addresses several independent causes of memory pressure in the echo (catch-all) path.

### 1. `GOMEMLIMIT` (new `internal/memlimit`)
Go's GC was unaware of the cgroup limit and let the heap grow until the kernel OOM-killed the process. On startup Cosmoparrot now detects the container's cgroup memory limit (v2 `memory.max`, v1 `memory.limit_in_bytes`) and sets a soft limit at 90% of it, leaving headroom for non-heap memory. An explicit `GOMEMLIMIT` env var still takes precedence.

### 2. Stop logging request bodies
The logger's `${body}` tag did `output.Write(c.Body())` — materializing the entire payload into the log buffer for every request, a major memory amplifier under load that also defeated request-body streaming. The body is no longer logged; request line and headers still are.

### 3. Body mirroring via `json.RawMessage`
The echo handler decoded the request body into a `map[string]interface{}` (several times the raw size) and re-encoded it for the response. It now validates with `json.Valid` and echoes the raw bytes verbatim, keeping per-request memory close to the payload size.

### 4. Skip reading the request body when `mirrorBody=false`
The handler called `c.Body()` for every request, buffering the full payload even when the client set `mirrorBody=false` — and held it resident during `responseDelay` sleeps. The body is now read only when it is echoed back. When mirroring is disabled it is neither read, echoed, stored, nor validated (**no `400` on malformed JSON**), keeping large non-mirrored payloads off-heap.

### 5. Drain the streamed body when not mirroring
Not reading the streamed body left it unread; fasthttp does not drain the connection reader on stream release, so leftover bytes broke keep-alive and closed connections early for large bodies. The body is now drained to `io.Discard` (pooled buffer, no full-payload buffering) so connections are reused.

## Docs
- README: documented the `mirrorBody=false` behavior, the request store (what it is, and that an empty `storeKeyRequestHeaders` disables it — avoid per-request-unique keys like trace ids), and the `GOMEMLIMIT` auto-detection.

## Not included (possible follow-ups)
- `BodyLimit` wiring and a configurable `maxResponseSize` to bound worst-case per-request/response memory (large `responseSize` responses are still buffered + pooled by fasthttp).
- A configurable `GOMEMLIMIT` ratio (currently fixed at 90%).
- Guarding the cache store path (`any.go`), which is still unbounded per key. Mitigated operationally via config (empty `storeKeyRequestHeaders`), not in code.

## Verification
`gofmt` clean, `go build`, `go vet`, `go test ./...` → 68 passed.
